### PR TITLE
Add dark/light theme toggle

### DIFF
--- a/front/src/components/FilmCard.jsx
+++ b/front/src/components/FilmCard.jsx
@@ -28,14 +28,14 @@ export default function FilmCard({ film }) {
         onKeyDown={onKeyDown}
         className="cursor-pointer outline-none"
       >
-        <article className="relative overflow-hidden rounded-[40px] border border-white/10 bg-white/5 shadow-[0_24px_80px_rgba(0,0,0,0.55)] transition hover:scale-[1.01]">
+        <article className="relative overflow-hidden rounded-[40px] shadow-[0_24px_80px_rgba(0,0,0,0.55)] transition hover:scale-[1.01]" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)' }}>
           <div className="flex justify-between items-start p-4">
             <div className="flex flex-col gap-2">
               <span className="inline-flex rounded-full border border-purple-500/50 bg-purple-600/30 px-4 py-2 text-[10px] font-black tracking-wide">
                 {film.category}
               </span>
 
-              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[10px] font-black tracking-wide text-white/90">
+              <span className="inline-flex rounded-full border border-white/15 bg-white/10 px-4 py-2 text-[10px] font-black tracking-wide opacity-90">
                 {film.ai}
               </span>
             </div>
@@ -56,20 +56,20 @@ export default function FilmCard({ film }) {
 
           <div className="mt-6 grid grid-cols-2 gap-10">
             <div>
-              <div className="text-[12px] font-black tracking-widest text-white/50">
+              <div className="text-[12px] font-black tracking-widest opacity-50">
                 RÉALISATEUR
               </div>
-              <div className="mt-3 text-lg font-semibold text-white/90 whitespace-nowrap">
+              <div className="mt-3 text-lg font-semibold opacity-90 whitespace-nowrap">
                 {film.director}
               </div>
             </div>
 
             <div className="text-right">
-              <div className="text-[12px] font-black tracking-widest text-white/50">
+              <div className="text-[12px] font-black tracking-widest opacity-50">
                 ORIGINE
               </div>
 
-              <div className="mt-3 flex items-center justify-end gap-2 text-xl font-semibold text-white/90">
+              <div className="mt-3 flex items-center justify-end gap-2 text-xl font-semibold opacity-90">
                 <img src={Globe} alt="Globe" className="h-4 w-4 opacity-80" />
                 <span>{film.origin}</span>
               </div>

--- a/front/src/components/Footer.css
+++ b/front/src/components/Footer.css
@@ -1,8 +1,8 @@
 /* Footer */
 .footer {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 4rem 2rem 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--border-color);
 }
 
 .footer-container {
@@ -20,7 +20,7 @@
 .footer-logo {
   font-size: 2rem;
   font-weight: 800;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 1.5rem 0;
 }
 
@@ -32,7 +32,7 @@
 }
 
 .footer-tagline {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 0.95rem;
   font-style: italic;
   line-height: 1.6;
@@ -50,18 +50,18 @@
   height: 3rem;
   border-radius: 50%;
   background: transparent;
-  border: 1px solid rgba(255, 255, 255, 0.15);
+  border: 1px solid var(--border-color);
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   transition: all 0.3s ease;
 }
 
 .social-link:hover {
   background: rgba(255, 255, 255, 0.05);
   border-color: rgba(255, 255, 255, 0.3);
-  color: white;
+  color: var(--text-primary);
 }
 
 .social-link svg {
@@ -89,14 +89,14 @@
 }
 
 .footer-link {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   font-size: 1rem;
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 .footer-link:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 .footer-newsletter {
@@ -107,7 +107,7 @@
 }
 
 .newsletter-title {
-  color: white;
+  color: var(--text-primary);
   font-size: 1.75rem;
   font-weight: 700;
   margin: 0 0 2rem 0;
@@ -125,12 +125,12 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.75rem;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.95rem;
 }
 
 .newsletter-input::placeholder {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
 }
 
 .newsletter-input:focus {
@@ -157,7 +157,7 @@
 
 .footer-bottom {
   padding-top: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--border-color);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -170,7 +170,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   font-size: 0.75rem;
   letter-spacing: 0.1em;
 }
@@ -180,13 +180,13 @@
 }
 
 .footer-bottom-link {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 .footer-bottom-link:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 /* Responsive */

--- a/front/src/components/Navbar.jsx
+++ b/front/src/components/Navbar.jsx
@@ -1,8 +1,10 @@
 import { useState } from "react";
 import { Link } from "react-router";
-import { Search, Home, Trophy, Calendar, User } from "lucide-react";
+import { Search, Home, Trophy, Calendar, User, Sun, Moon } from "lucide-react";
+import { useTheme } from "../contexts/ThemeContext.jsx";
 
 export default function Navbar() {
+  const { theme, toggleTheme } = useTheme();
   const firstName = localStorage.getItem("first_name");
   const role = localStorage.getItem("role");
   const [menuOpen, setMenuOpen] = useState(false);
@@ -17,8 +19,8 @@ export default function Navbar() {
   }
 
   return (
-    <nav className="bg-black p-4 md:p-5">
-      <div className="flex bg-white/5 text-white border border-white/10 rounded-full justify-between items-center px-6 h-16">
+    <nav className="p-4 md:p-5" style={{ background: 'var(--nav-bg)' }}>
+      <div className="flex rounded-full justify-between items-center px-6 h-16" style={{ background: 'var(--bg-card)', color: 'var(--text-primary)', border: '1px solid var(--border-color)' }}>
         {/* Logo */}
         <Link to="/" className="flex font-bold gap-1 px-3 text-xl flex-shrink-0">
           <span>MARS</span>
@@ -29,25 +31,28 @@ export default function Navbar() {
 
         {/* Center icons - desktop */}
         <div className="hidden md:flex items-center gap-8">
-          <Link to="/films" className="text-white/70 hover:text-white transition-colors" title="Films">
+          <Link to="/films" className="hover:opacity-100 transition-colors" style={{ color: 'var(--text-secondary)' }} title="Films">
             <Search className="w-5 h-5" />
           </Link>
-          <Link to="/" className="text-white/70 hover:text-white transition-colors" title="Accueil">
+          <Link to="/" className="hover:opacity-100 transition-colors" style={{ color: 'var(--text-secondary)' }} title="Accueil">
             <Home className="w-5 h-5" />
           </Link>
-          <Link to="/palmares" className="text-white/70 hover:text-white transition-colors" title="Palmarès">
+          <Link to="/palmares" className="hover:opacity-100 transition-colors" style={{ color: 'var(--text-secondary)' }} title="Palmarès">
             <Trophy className="w-5 h-5" />
           </Link>
-          <Link to="/agenda" className="text-white/70 hover:text-white transition-colors" title="Agenda">
+          <Link to="/agenda" className="hover:opacity-100 transition-colors" style={{ color: 'var(--text-secondary)' }} title="Agenda">
             <Calendar className="w-5 h-5" />
           </Link>
-          <Link to="/contact" className="text-white/70 hover:text-white transition-colors" title="Contact">
+          <Link to="/contact" className="hover:opacity-100 transition-colors" style={{ color: 'var(--text-secondary)' }} title="Contact">
             <User className="w-5 h-5" />
           </Link>
         </div>
 
         {/* Right side */}
         <div className="hidden md:flex items-center gap-4">
+          <button onClick={toggleTheme} className="p-2 rounded-full transition-colors" style={{ color: 'var(--text-secondary)' }} title="Toggle theme">
+            {theme === "dark" ? <Sun className="w-5 h-5" /> : <Moon className="w-5 h-5" />}
+          </button>
           {firstName ? (
             <>
               {role === "ADMIN" && (
@@ -97,15 +102,19 @@ export default function Navbar() {
 
       {/* Mobile menu */}
       {menuOpen && (
-        <div className="md:hidden mt-2 bg-white/5 border border-white/10 rounded-2xl text-white">
+        <div className="md:hidden mt-2 rounded-2xl" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}>
           <div className="flex flex-col gap-4 px-6 py-6">
-            <Link to="/" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">ACCUEIL</Link>
-            <Link to="/films" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">FILMS</Link>
-            <Link to="/palmares" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">PALMARÈS</Link>
-            <Link to="/agenda" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">AGENDA</Link>
-            <Link to="/contact" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">CONTACT</Link>
+            <button onClick={toggleTheme} className="flex items-center gap-2 text-sm" style={{ color: 'var(--text-secondary)' }}>
+              {theme === "dark" ? <Sun className="w-4 h-4" /> : <Moon className="w-4 h-4" />}
+              {theme === "dark" ? "Mode clair" : "Mode sombre"}
+            </button>
+            <Link to="/" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>ACCUEIL</Link>
+            <Link to="/films" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>FILMS</Link>
+            <Link to="/palmares" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>PALMARÈS</Link>
+            <Link to="/agenda" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>AGENDA</Link>
+            <Link to="/contact" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>CONTACT</Link>
             {role !== "ADMIN" && role !== "JURY" && (
-              <Link to="/soumettre" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">SOUMETTRE</Link>
+              <Link to="/soumettre" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>SOUMETTRE</Link>
             )}
             {firstName ? (
               <>
@@ -121,7 +130,7 @@ export default function Navbar() {
               </>
             ) : (
               <>
-                <Link to="/auth/login" onClick={() => setMenuOpen(false)} className="text-white/80 hover:text-white text-sm">CONNEXION</Link>
+                <Link to="/auth/login" onClick={() => setMenuOpen(false)} className="hover:opacity-100 text-sm" style={{ color: 'var(--text-secondary)' }}>CONNEXION</Link>
                 <Link to="/auth/register" onClick={() => setMenuOpen(false)} className="text-white bg-[linear-gradient(180deg,rgba(81,162,255,1)_0%,rgba(152,16,250,1)_100%)] px-5 py-2 rounded-full text-sm text-center font-bold">
                   INSCRIPTION
                 </Link>

--- a/front/src/contexts/ThemeContext.jsx
+++ b/front/src/contexts/ThemeContext.jsx
@@ -1,0 +1,31 @@
+import { createContext, useContext, useState, useEffect } from "react";
+
+const ThemeContext = createContext();
+
+export function ThemeProvider({ children }) {
+  const [theme, setTheme] = useState(() => {
+    return localStorage.getItem("theme") || "dark";
+  });
+
+  useEffect(() => {
+    document.documentElement.dataset.theme = theme;
+  }, [theme]);
+
+  function toggleTheme() {
+    setTheme((prev) => {
+      const next = prev === "dark" ? "light" : "dark";
+      localStorage.setItem("theme", next);
+      return next;
+    });
+  }
+
+  return (
+    <ThemeContext.Provider value={{ theme, toggleTheme }}>
+      {children}
+    </ThemeContext.Provider>
+  );
+}
+
+export function useTheme() {
+  return useContext(ThemeContext);
+}

--- a/front/src/index.css
+++ b/front/src/index.css
@@ -3,6 +3,29 @@
 @plugin "@tailwindcss/forms";
 @plugin "@tailwindcss/typography";
 
+/* Theme Variables */
+:root {
+  --bg-primary: #0a0a0a;
+  --bg-secondary: #1a1a1a;
+  --bg-card: rgba(255, 255, 255, 0.05);
+  --text-primary: #ffffff;
+  --text-secondary: rgba(255, 255, 255, 0.6);
+  --text-muted: rgba(255, 255, 255, 0.4);
+  --border-color: rgba(255, 255, 255, 0.1);
+  --nav-bg: #000000;
+}
+
+[data-theme="light"] {
+  --bg-primary: #ffffff;
+  --bg-secondary: #f5f5f5;
+  --bg-card: rgba(0, 0, 0, 0.05);
+  --text-primary: #1a1a1a;
+  --text-secondary: rgba(0, 0, 0, 0.6);
+  --text-muted: rgba(0, 0, 0, 0.4);
+  --border-color: rgba(0, 0, 0, 0.1);
+  --nav-bg: #ffffff;
+}
+
 /* Global Reset */
 * {
   margin: 0;
@@ -13,6 +36,10 @@
 html, body, #root {
   min-height: 100vh;
   width: 100%;
+}
+
+html {
+  transition: color 0.3s ease, background-color 0.3s ease;
 }
 
 body {

--- a/front/src/layouts/PublicLayout.jsx
+++ b/front/src/layouts/PublicLayout.jsx
@@ -4,7 +4,7 @@ import Footer from "../components/Footer";
 
 export default function PublicLayout() {
   return (
-    <div className="min-h-screen flex flex-col">
+    <div className="min-h-screen flex flex-col" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       <header className="sticky top-0 left-0 right-0 z-50">
         <Navbar />
       </header>

--- a/front/src/main.jsx
+++ b/front/src/main.jsx
@@ -5,6 +5,7 @@ import { BrowserRouter, Route, Routes } from "react-router";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 
 import "./index.css";
+import { ThemeProvider } from "./contexts/ThemeContext.jsx";
 import Home from "./pages/public/Home.jsx";
 import Films from "./pages/public/Films.jsx";
 import Palmares from "./pages/public/Palmares.jsx";
@@ -33,6 +34,7 @@ const queryClient = new QueryClient({
 
 createRoot(document.getElementById("root")).render(
   <StrictMode>
+    <ThemeProvider>
     <BrowserRouter>
       <QueryClientProvider client={queryClient}>
         <Routes>
@@ -81,5 +83,6 @@ createRoot(document.getElementById("root")).render(
         </Routes>
       </QueryClientProvider>
     </BrowserRouter>
+    </ThemeProvider>
   </StrictMode>,
 );

--- a/front/src/pages/Gallerie.jsx
+++ b/front/src/pages/Gallerie.jsx
@@ -29,7 +29,7 @@ export default function GalerieDesFilmsPage() {
   }, [films, page]);
 
   return (
-    <div className="min-h-screen bg-gray-950 text-white font-sans p-4">
+    <div className="min-h-screen font-sans p-4" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       <main className="mx-auto max-w-[1180px] px-6 pb-10 pt-10">
         {/* Title */}
         <section className="mb-8">
@@ -114,7 +114,7 @@ export default function GalerieDesFilmsPage() {
             </button>
           </div>
 
-          <div className="text-[11px] font-black tracking-widest text-white/50">
+          <div className="text-[11px] font-black tracking-widest opacity-50">
             PAGE {page} SUR {totalPages} — {films.length} FILMS TROUVÉS
           </div>
         </section>

--- a/front/src/pages/public/Agenda.css
+++ b/front/src/pages/public/Agenda.css
@@ -1,6 +1,6 @@
 /* Agenda Page */
 .agenda-page {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   min-height: 100vh;
   padding-bottom: 4rem;
 }
@@ -34,7 +34,7 @@
 .agenda-date {
   font-size: clamp(3rem, 10vw, 6rem);
   font-weight: 800;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
   letter-spacing: -0.02em;
 }
@@ -88,7 +88,7 @@
 }
 
 .plateforme-description {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   font-size: 0.95rem;
   line-height: 1.5;
   margin: 0;
@@ -101,19 +101,19 @@
   gap: 0.75rem;
   margin-bottom: 1.5rem;
   padding-bottom: 1rem;
-  border-bottom: 1px solid rgba(255, 255, 255, 0.1);
+  border-bottom: 1px solid var(--border-color);
 }
 
 .section-header svg {
   width: 1.25rem;
   height: 1.25rem;
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
 }
 
 .section-header h2 {
   font-size: 1rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.8);
+  color: var(--text-primary);
   letter-spacing: 0.1em;
   margin: 0;
 }
@@ -136,7 +136,7 @@
   align-items: center;
   gap: 1.5rem;
   padding: 1.25rem 1.5rem;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-card);
   border-radius: 0.75rem;
   transition: background 0.3s ease;
 }
@@ -148,7 +148,7 @@
 .programme-time {
   font-size: 1.25rem;
   font-weight: 700;
-  color: white;
+  color: var(--text-primary);
   min-width: 70px;
 }
 
@@ -165,7 +165,7 @@
 .programme-type {
   font-size: 0.7rem;
   font-weight: 600;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   letter-spacing: 0.15em;
 }
 
@@ -175,7 +175,7 @@
 
 .programme-label {
   font-size: 1rem;
-  color: rgba(255, 255, 255, 0.9);
+  color: var(--text-primary);
 }
 
 /* Accès Section */
@@ -231,13 +231,13 @@
 .acces-content h3 {
   font-size: 1rem;
   font-weight: 600;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
 }
 
 .acces-content p {
   font-size: 0.9rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   margin: 0;
   line-height: 1.5;
 }
@@ -270,7 +270,7 @@
 .workshops-title {
   font-size: 1.75rem;
   font-weight: 800;
-  color: white;
+  color: var(--text-primary);
   margin: 0;
   letter-spacing: -0.01em;
 }
@@ -295,7 +295,7 @@
 
 .workshops-description {
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   letter-spacing: 0.05em;
   line-height: 1.6;
   margin: 0 0 2rem 0;
@@ -309,7 +309,7 @@
 
 .workshop-item {
   padding: 1.5rem;
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-card);
   border-radius: 1rem;
 }
 
@@ -324,21 +324,21 @@
 .workshop-title {
   font-size: 1rem;
   font-weight: 700;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 0.75rem 0;
   line-height: 1.3;
 }
 
 .workshop-coach {
   font-size: 0.75rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   letter-spacing: 0.1em;
   margin: 0 0 1rem 0;
 }
 
 .workshop-places {
   font-size: 0.7rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   letter-spacing: 0.05em;
   margin: 0 0 1rem 0;
 }
@@ -353,7 +353,7 @@
   background: transparent;
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 9999px;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.8rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -363,7 +363,7 @@
 
 .workshop-btn:hover {
   background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--text-muted);
 }
 
 /* Modal */
@@ -379,7 +379,7 @@
 }
 
 .modal-content {
-  background: #1a1a1a;
+  background: var(--bg-secondary);
   border-radius: 1.5rem;
   padding: 2rem;
   max-width: 450px;
@@ -393,20 +393,20 @@
   right: 1rem;
   background: none;
   border: none;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 1.5rem;
   cursor: pointer;
   line-height: 1;
 }
 
 .modal-close:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 .modal-title {
   font-size: 1.5rem;
   font-weight: 700;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 0.5rem 0;
 }
 
@@ -433,12 +433,12 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.5rem;
-  color: white;
+  color: var(--text-primary);
   font-size: 1rem;
 }
 
 .reservation-form input::placeholder {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
 }
 
 .reservation-form input:focus {
@@ -451,7 +451,7 @@
   background: linear-gradient(135deg, #e879f9 0%, #a855f7 100%);
   border: none;
   border-radius: 9999px;
-  color: white;
+  color: var(--text-primary);
   font-size: 1rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -486,18 +486,18 @@
 
 .toast-message.success {
   background: #22c55e;
-  color: white;
+  color: var(--text-primary);
 }
 
 .toast-message.error {
   background: #ef4444;
-  color: white;
+  color: var(--text-primary);
 }
 
 .toast-message button {
   background: none;
   border: none;
-  color: white;
+  color: var(--text-primary);
   font-size: 1.25rem;
   cursor: pointer;
   line-height: 1;

--- a/front/src/pages/public/Contact.jsx
+++ b/front/src/pages/public/Contact.jsx
@@ -2,7 +2,7 @@ import React from "react";
 
 export default function Contact() {
   return (
-    <div className="bg-gray-950 text-white min-h-screen flex flex-col items-center px-6 py-16">
+    <div className="min-h-screen flex flex-col items-center px-6 py-16" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       
       {/* Заголовок по центру */}
       <h1 className="text-4xl font-bold mb-12 text-center">
@@ -16,8 +16,8 @@ export default function Contact() {
           <div className="bg-blue-600/20 p-4 rounded-xl text-2xl">🚆</div>
           <div>
             <h3 className="text-xl font-semibold">Transports en commun</h3>
-            <p className="text-gray-400">Tram T2 / T3 – Arrêt Arenc Le Silo.</p>
-            <p className="text-gray-400">Métro M2 – Station Désirée Clary.</p>
+            <p className="" style={{ color: 'var(--text-secondary)' }}>Tram T2 / T3 – Arrêt Arenc Le Silo.</p>
+            <p className="" style={{ color: 'var(--text-secondary)' }}>Métro M2 – Station Désirée Clary.</p>
           </div>
         </div>
 
@@ -25,8 +25,8 @@ export default function Contact() {
           <div className="bg-green-600/20 p-4 rounded-xl text-2xl">🚗</div>
           <div>
             <h3 className="text-xl font-semibold">Voiture</h3>
-            <p className="text-gray-400">Autoroute A55 – Sortie 2.</p>
-            <p className="text-gray-400">Parking Indigo Quai du Lazaret à 200m.</p>
+            <p className="" style={{ color: 'var(--text-secondary)' }}>Autoroute A55 – Sortie 2.</p>
+            <p className="" style={{ color: 'var(--text-secondary)' }}>Parking Indigo Quai du Lazaret à 200m.</p>
           </div>
         </div>
 
@@ -34,7 +34,7 @@ export default function Contact() {
           <div className="bg-purple-600/20 p-4 rounded-xl text-2xl">📍</div>
           <div>
             <h3 className="text-xl font-semibold">Adresse</h3>
-            <p className="text-gray-400">
+            <p className="" style={{ color: 'var(--text-secondary)' }}>
               155 Rue Peyssonnel, 13002 Marseille (Entrée principale)
             </p>
           </div>

--- a/front/src/pages/public/Films.jsx
+++ b/front/src/pages/public/Films.jsx
@@ -58,17 +58,17 @@ export default function Films() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <p className="text-white/60">Chargement...</p>
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--bg-primary)' }}>
+        <p style={{ color: 'var(--text-secondary)' }}>Chargement...</p>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       <div className="max-w-6xl mx-auto">
-        <h1 className="text-2xl sm:text-4xl font-bold text-white mb-2">SÉLECTION OFFICIELLE</h1>
-        <p className="text-white/60 mb-8">Films retenus et finalistes du festival Mars.A.I</p>
+        <h1 className="text-2xl sm:text-4xl font-bold mb-2">SÉLECTION OFFICIELLE</h1>
+        <p className="opacity-60 mb-8">Films retenus et finalistes du festival Mars.A.I</p>
 
         {/* Filters */}
         <div className="space-y-4 mb-8">
@@ -79,12 +79,12 @@ export default function Films() {
               placeholder="Rechercher un film…"
               value={search}
               onChange={(e) => setSearch(e.target.value)}
-              className="flex-1 bg-gray-900 border border-white/10 rounded-lg px-4 py-2 text-white placeholder-white/40 focus:outline-none focus:border-purple-500"
+              className="flex-1 rounded-lg px-4 py-2 focus:outline-none focus:border-purple-500" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
             />
             <select
               value={sort}
               onChange={(e) => setSort(e.target.value)}
-              className="bg-gray-900 border border-white/10 rounded-lg px-4 py-2 text-white/80 focus:outline-none focus:border-purple-500"
+              className="rounded-lg px-4 py-2 focus:outline-none focus:border-purple-500" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
             >
               <option value="recent">Plus récents</option>
               <option value="oldest">Plus anciens</option>
@@ -103,7 +103,7 @@ export default function Films() {
                   className={`px-3 py-1.5 rounded-lg text-sm transition-colors ${
                     type === t
                       ? "bg-purple-600 text-white"
-                      : "bg-gray-900 text-white/60 border border-white/10 hover:border-purple-500/50"
+                      : "border hover:border-purple-500/50"
                   }`}
                 >
                   {t}
@@ -114,7 +114,7 @@ export default function Films() {
               <select
                 value={language}
                 onChange={(e) => setLanguage(e.target.value)}
-                className="bg-gray-900 border border-white/10 rounded-lg px-4 py-1.5 text-white/80 text-sm focus:outline-none focus:border-purple-500"
+                className="rounded-lg px-4 py-1.5 text-sm focus:outline-none focus:border-purple-500" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
               >
                 <option value="Toutes">Toutes les langues</option>
                 {languages.map((l) => (
@@ -146,24 +146,24 @@ export default function Films() {
 
         {/* Film grid */}
         {filtered.length === 0 ? (
-          <p className="text-white/40 text-center py-20">Aucun film ne correspond aux filtres.</p>
+          <p className="opacity-40 text-center py-20">Aucun film ne correspond aux filtres.</p>
         ) : (
           <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-6">
             {filtered.map((film) => (
-              <div key={film.id} className="bg-gray-900 rounded-xl overflow-hidden border border-white/10 hover:border-purple-500/50 transition-all">
+              <div key={film.id} className="rounded-xl overflow-hidden hover:border-purple-500/50 transition-all" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
                 <div className="aspect-video bg-gray-800 relative">
                   {film.thumbnail ? (
                     <img src={`${API_URL}${film.thumbnail}`} alt={film.title} className="w-full h-full object-cover" />
                   ) : (
-                    <div className="w-full h-full flex items-center justify-center text-white/20">16:9</div>
+                    <div className="w-full h-full flex items-center justify-center opacity-20">16:9</div>
                   )}
                   {film.status === "finalist" && (
                     <span className="absolute top-2 right-2 bg-purple-600 text-white text-xs px-2 py-1 rounded">FINALISTE</span>
                   )}
                 </div>
                 <div className="p-4">
-                  <h3 className="text-white font-semibold">{film.title}</h3>
-                  <p className="text-white/50 text-sm mt-1">{film.language || ""}</p>
+                  <h3 className="font-semibold">{film.title}</h3>
+                  <p className="opacity-50 text-sm mt-1">{film.language || ""}</p>
                   {film.tags && film.tags.length > 0 && (
                     <div className="flex flex-wrap gap-1 mt-2">
                       {film.tags.map((tag) => (

--- a/front/src/pages/public/Home.css
+++ b/front/src/pages/public/Home.css
@@ -59,7 +59,7 @@
   font-weight: 800;
   letter-spacing: -0.02em;
   line-height: 1;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 1.5rem 0;
 }
 
@@ -75,7 +75,7 @@
   font-size: clamp(1.25rem, 3vw, 2rem);
   font-weight: 700;
   letter-spacing: 0.05em;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 1rem 0;
 }
 
@@ -87,7 +87,7 @@
 /* Subtitle */
 .subtitle {
   font-size: clamp(1rem, 2vw, 1.25rem);
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   margin: 0 0 0.5rem 0;
   font-weight: 400;
 }
@@ -95,7 +95,7 @@
 /* Immersion text */
 .immersion-text {
   font-size: clamp(1rem, 2vw, 1.25rem);
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-style: italic;
   margin: 0 0 3rem 0;
 }
@@ -152,7 +152,7 @@
 }
 
 .btn-secondary:hover {
-  border-color: rgba(255, 255, 255, 0.6);
+  border-color: var(--text-secondary);
   background: rgba(255, 255, 255, 0.05);
 }
 
@@ -258,7 +258,7 @@
   justify-content: center;
   padding: 1.25rem 3rem;
   background: linear-gradient(135deg, #e879f9 0%, #a855f7 50%, #7c3aed 100%);
-  color: white;
+  color: var(--text-primary);
   border: none;
   border-radius: 9999px;
   font-size: 1rem;
@@ -279,7 +279,7 @@
 /* ==================== */
 
 .objectives-section {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 6rem 2rem;
 }
 
@@ -292,7 +292,7 @@
   font-size: clamp(3rem, 8vw, 5rem);
   font-weight: 800;
   line-height: 1;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 4rem 0;
   letter-spacing: -0.02em;
 }
@@ -312,7 +312,7 @@
 
 .objective-card {
   padding: 2rem 0;
-  border-top: 1px solid rgba(255, 255, 255, 0.1);
+  border-top: 1px solid var(--border-color);
 }
 
 .objective-icon {
@@ -330,13 +330,13 @@
 .objective-name {
   font-size: 1.125rem;
   font-weight: 700;
-  color: white;
+  color: var(--text-primary);
   letter-spacing: 0.05em;
   margin: 0 0 1rem 0;
 }
 
 .objective-description {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 1rem;
   line-height: 1.6;
   margin: 0;
@@ -347,7 +347,7 @@
 /* ==================== */
 
 .films-section {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 6rem 2rem;
   min-height: 100vh;
 }
@@ -394,7 +394,7 @@
   font-size: clamp(3rem, 8vw, 6rem);
   font-weight: 800;
   line-height: 1;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 2rem 0;
   letter-spacing: -0.02em;
 }
@@ -407,7 +407,7 @@
 }
 
 .films-description {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   font-size: 1.125rem;
   line-height: 1.7;
   margin: 0;
@@ -431,7 +431,7 @@
 }
 
 .btn-selection:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 .btn-selection-arrow {
@@ -451,7 +451,7 @@
 }
 
 .btn-selection:hover .btn-selection-arrow {
-  border-color: rgba(255, 255, 255, 0.6);
+  border-color: var(--text-secondary);
   background: rgba(255, 255, 255, 0.05);
 }
 
@@ -511,7 +511,7 @@
 }
 
 .film-director {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   font-size: 0.75rem;
   letter-spacing: 0.15em;
   margin: 0;
@@ -544,7 +544,7 @@
   padding: 0.5rem 1.25rem;
   background: linear-gradient(135deg, #c084fc 0%, #a855f7 100%);
   border-radius: 0.5rem;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.875rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -627,7 +627,7 @@
 /* ==================== */
 
 .conferences-section {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 6rem 2rem;
 }
 
@@ -640,7 +640,7 @@
   font-size: clamp(2.5rem, 6vw, 4.5rem);
   font-weight: 800;
   line-height: 1.1;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 2rem 0;
   letter-spacing: -0.02em;
 }
@@ -662,7 +662,7 @@
 }
 
 .conferences-list li {
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-secondary);
   font-size: 1.125rem;
   line-height: 1.8;
   padding-left: 1.5rem;
@@ -673,7 +673,7 @@
   content: counter(list-item) ".";
   position: absolute;
   left: 0;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
 }
 
 .conferences-list li {
@@ -688,7 +688,7 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.2);
   border-radius: 9999px;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.875rem;
   font-weight: 600;
   letter-spacing: 0.05em;
@@ -699,7 +699,7 @@
 
 .btn-agenda:hover {
   background: rgba(255, 255, 255, 0.1);
-  border-color: rgba(255, 255, 255, 0.4);
+  border-color: var(--text-muted);
 }
 
 .btn-agenda-icon {
@@ -728,7 +728,7 @@
 }
 
 .event-card-dark {
-  background: #1a1a1a;
+  background: var(--bg-secondary);
   border: 1px solid #22c55e;
 }
 
@@ -766,7 +766,7 @@
 }
 
 .event-card-dark .event-name {
-  color: white;
+  color: var(--text-primary);
 }
 
 .event-description {
@@ -780,7 +780,7 @@
 }
 
 .event-card-dark .event-description {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
 }
 
 /* ==================== */
@@ -788,7 +788,7 @@
 /* ==================== */
 
 .sponsors-section {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 6rem 2rem;
 }
 
@@ -803,7 +803,7 @@
   align-items: center;
   justify-content: center;
   gap: 1rem;
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 0.875rem;
   letter-spacing: 0.2em;
   margin-bottom: 1.5rem;
@@ -818,7 +818,7 @@
 .sponsors-title {
   font-size: clamp(2rem, 5vw, 3.5rem);
   font-weight: 800;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 4rem 0;
   letter-spacing: -0.02em;
 }
@@ -838,7 +838,7 @@
 }
 
 .sponsor-card {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-card);
   border: 1px solid rgba(255, 255, 255, 0.05);
   border-radius: 1rem;
   padding: 2rem;
@@ -865,7 +865,7 @@
 /* ==================== */
 
 .location-section {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 6rem 2rem;
 }
 
@@ -881,7 +881,7 @@
   padding: 0.5rem 1rem;
   background: rgba(255, 255, 255, 0.05);
   border-radius: 9999px;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.875rem;
   letter-spacing: 0.1em;
   margin-bottom: 1.5rem;
@@ -898,7 +898,7 @@
   line-height: 1;
   margin: 0 0 3rem 0;
   letter-spacing: -0.02em;
-  color: white;
+  color: var(--text-primary);
 }
 
 .location-title-outline {
@@ -923,14 +923,14 @@
 }
 
 .location-address {
-  color: white;
+  color: var(--text-primary);
   font-size: 1rem;
   font-weight: 500;
   line-height: 1.5;
 }
 
 .location-access {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 0.875rem;
   letter-spacing: 0.05em;
 }
@@ -943,7 +943,7 @@
 }
 
 .venue-card {
-  background: rgba(255, 255, 255, 0.03);
+  background: var(--bg-card);
   border-radius: 1rem;
   padding: 2rem;
 }
@@ -958,7 +958,7 @@
 }
 
 .venue-description {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   font-size: 1rem;
   line-height: 1.7;
   margin: 0;
@@ -978,9 +978,9 @@
 /* ==================== */
 
 .footer {
-  background: #0a0a0a;
+  background: var(--bg-primary);
   padding: 4rem 2rem 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--border-color);
 }
 
 .footer-container {
@@ -998,7 +998,7 @@
 .footer-logo {
   font-size: 2rem;
   font-weight: 800;
-  color: white;
+  color: var(--text-primary);
   margin: 0 0 1rem 0;
 }
 
@@ -1010,7 +1010,7 @@
 }
 
 .footer-tagline {
-  color: rgba(255, 255, 255, 0.5);
+  color: var(--text-secondary);
   font-size: 0.95rem;
   font-style: italic;
   line-height: 1.6;
@@ -1031,13 +1031,13 @@
   display: flex;
   align-items: center;
   justify-content: center;
-  color: rgba(255, 255, 255, 0.7);
+  color: var(--text-secondary);
   transition: all 0.3s ease;
 }
 
 .social-link:hover {
   background: rgba(255, 255, 255, 0.1);
-  color: white;
+  color: var(--text-primary);
 }
 
 .social-link svg {
@@ -1065,14 +1065,14 @@
 }
 
 .footer-link {
-  color: rgba(255, 255, 255, 0.6);
+  color: var(--text-secondary);
   font-size: 0.95rem;
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 .footer-link:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 .footer-newsletter {
@@ -1083,7 +1083,7 @@
 }
 
 .newsletter-title {
-  color: white;
+  color: var(--text-primary);
   font-size: 1.5rem;
   font-weight: 700;
   margin: 0 0 1.5rem 0;
@@ -1101,12 +1101,12 @@
   background: rgba(255, 255, 255, 0.05);
   border: 1px solid rgba(255, 255, 255, 0.1);
   border-radius: 0.5rem;
-  color: white;
+  color: var(--text-primary);
   font-size: 0.95rem;
 }
 
 .newsletter-input::placeholder {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
 }
 
 .newsletter-input:focus {
@@ -1132,7 +1132,7 @@
 
 .footer-bottom {
   padding-top: 2rem;
-  border-top: 1px solid rgba(255, 255, 255, 0.05);
+  border-top: 1px solid var(--border-color);
   display: flex;
   justify-content: space-between;
   align-items: center;
@@ -1145,7 +1145,7 @@
   display: flex;
   align-items: center;
   gap: 1rem;
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   font-size: 0.75rem;
   letter-spacing: 0.1em;
 }
@@ -1155,13 +1155,13 @@
 }
 
 .footer-bottom-link {
-  color: rgba(255, 255, 255, 0.4);
+  color: var(--text-muted);
   text-decoration: none;
   transition: color 0.3s ease;
 }
 
 .footer-bottom-link:hover {
-  color: white;
+  color: var(--text-primary);
 }
 
 /* ==================== */

--- a/front/src/pages/public/Palmares.jsx
+++ b/front/src/pages/public/Palmares.jsx
@@ -11,45 +11,45 @@ export default function Palmares() {
 
   if (isLoading) {
     return (
-      <div className="min-h-screen bg-gray-950 flex items-center justify-center">
-        <p className="text-white/60">Chargement...</p>
+      <div className="min-h-screen flex items-center justify-center" style={{ background: 'var(--bg-primary)' }}>
+        <p style={{ color: 'var(--text-secondary)' }}>Chargement...</p>
       </div>
     );
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       <div className="max-w-4xl mx-auto">
-        <h1 className="text-2xl sm:text-4xl font-bold text-white mb-2">PALMARÈS</h1>
-        <p className="text-white/60 mb-12">Les lauréats du festival Mars.A.I</p>
+        <h1 className="text-2xl sm:text-4xl font-bold mb-2">PALMARÈS</h1>
+        <p className="opacity-60 mb-12">Les lauréats du festival Mars.A.I</p>
 
         {(!awards || awards.length === 0) ? (
-          <p className="text-white/40 text-center py-20">Le palmarès sera annoncé prochainement.</p>
+          <p className="opacity-40 text-center py-20">Le palmarès sera annoncé prochainement.</p>
         ) : (
           <div className="space-y-8">
             {awards.map((award) => (
-              <div key={award.id} className="bg-gray-900 rounded-xl p-6 border border-white/10">
+              <div key={award.id} className="rounded-xl p-6" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
                 <h2 className="text-xl font-bold text-purple-400 mb-1">{award.name}</h2>
-                {award.description && <p className="text-white/50 text-sm mb-4">{award.description}</p>}
+                {award.description && <p className="opacity-50 text-sm mb-4">{award.description}</p>}
                 {award.films && award.films.length > 0 ? (
                   <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
                     {award.films.map((film) => (
-                      <div key={film.id} className="flex gap-4 bg-gray-800 rounded-lg p-3">
+                      <div key={film.id} className="flex gap-4 rounded-lg p-3" style={{ background: 'var(--bg-card)' }}>
                         <div className="w-24 h-14 bg-gray-700 rounded overflow-hidden flex-shrink-0">
                           {film.thumbnail ? (
                             <img src={`${API_URL}${film.thumbnail}`} alt={film.title} className="w-full h-full object-cover" />
                           ) : (
-                            <div className="w-full h-full flex items-center justify-center text-white/20 text-xs">16:9</div>
+                            <div className="w-full h-full flex items-center justify-center opacity-20 text-xs">16:9</div>
                           )}
                         </div>
                         <div>
-                          <h3 className="text-white font-medium text-sm">{film.title}</h3>
+                          <h3 className="font-medium text-sm">{film.title}</h3>
                         </div>
                       </div>
                     ))}
                   </div>
                 ) : (
-                  <p className="text-white/30 text-sm">Aucun lauréat désigné</p>
+                  <p className="opacity-30 text-sm">Aucun lauréat désigné</p>
                 )}
               </div>
             ))}

--- a/front/src/pages/public/Soumettre.jsx
+++ b/front/src/pages/public/Soumettre.jsx
@@ -64,10 +64,10 @@ export default function Soumettre() {
 
   if (submitSuccess) {
     return (
-      <div className="min-h-screen bg-gray-950 py-12 px-4 sm:px-6 lg:px-8">
+      <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
         <div className="max-w-2xl mx-auto text-center">
           <h1 className="text-3xl font-bold text-green-400 mb-4">Film soumis avec succès !</h1>
-          <p className="text-white/60 mb-8">Votre film a été enregistré et sera examiné par notre équipe.</p>
+          <p className="opacity-60 mb-8">Votre film a été enregistré et sera examiné par notre équipe.</p>
           <button onClick={() => navigate("/")} className="bg-purple-600 text-white px-6 py-3 rounded-lg hover:bg-purple-700">
             Retour à l'accueil
           </button>
@@ -77,24 +77,24 @@ export default function Soumettre() {
   }
 
   return (
-    <div className="min-h-screen bg-gray-950 py-12 px-4 sm:px-6 lg:px-8">
+    <div className="min-h-screen py-12 px-4 sm:px-6 lg:px-8" style={{ background: 'var(--bg-primary)', color: 'var(--text-primary)' }}>
       <div className="max-w-2xl mx-auto">
-        <h1 className="text-2xl sm:text-3xl font-bold text-white mb-2">SOUMETTRE MON FILM</h1>
-        <p className="text-white/60 mb-8">Inscrivez votre court-métrage IA au festival Mars.A.I</p>
+        <h1 className="text-2xl sm:text-3xl font-bold mb-2">SOUMETTRE MON FILM</h1>
+        <p className="opacity-60 mb-8">Inscrivez votre court-métrage IA au festival Mars.A.I</p>
 
         {!isLoggedIn ? (
-          <div className="bg-gray-900 rounded-xl p-6 border border-white/10 mb-8">
-            <h2 className="text-lg font-semibold text-white mb-4">Connectez-vous pour soumettre</h2>
+          <div className="rounded-xl p-6 mb-8" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
+            <h2 className="text-lg font-semibold mb-4">Connectez-vous pour soumettre</h2>
             {loginError && <p className="text-red-400 text-sm mb-3">{loginError}</p>}
             <div className="space-y-3">
               <input
                 type="email" placeholder="Email"
-                className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white placeholder-white/30"
+                className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                 value={loginData.email} onChange={(e) => setLoginData({ ...loginData, email: e.target.value })}
               />
               <input
                 type="password" placeholder="Mot de passe"
-                className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white placeholder-white/30"
+                className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                 value={loginData.password} onChange={(e) => setLoginData({ ...loginData, password: e.target.value })}
               />
               <button
@@ -104,7 +104,7 @@ export default function Soumettre() {
               >
                 {loginMutation.isPending ? "Connexion..." : "Se connecter"}
               </button>
-              <p className="text-white/40 text-sm text-center">
+              <p className="text-sm text-center opacity-40">
                 Pas de compte ? <a href="/auth/register" className="text-purple-400 hover:underline">S'inscrire</a>
               </p>
             </div>
@@ -113,107 +113,107 @@ export default function Soumettre() {
           <form onSubmit={(e) => { e.preventDefault(); submitMutation.mutate(); }} className="space-y-6">
             {submitError && <p className="text-red-400 text-sm">{submitError}</p>}
 
-            <div className="bg-gray-900 rounded-xl p-6 border border-white/10 space-y-4">
+            <div className="rounded-xl p-6 space-y-4" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
               <h2 className="text-lg font-semibold text-white">Informations du film</h2>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Titre *</label>
-                <input type="text" required className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">Titre *</label>
+                <input type="text" required className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.title} onChange={(e) => setFilmData({ ...filmData, title: e.target.value })} />
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-2 gap-4">
                 <div>
-                  <label className="text-white/60 text-sm block mb-1">Titre original</label>
-                  <input type="text" className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                  <label className="text-sm block mb-1 opacity-60">Titre original</label>
+                  <input type="text" className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                     value={filmData.original_title} onChange={(e) => setFilmData({ ...filmData, original_title: e.target.value })} />
                 </div>
                 <div>
-                  <label className="text-white/60 text-sm block mb-1">Titre anglais</label>
-                  <input type="text" className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                  <label className="text-sm block mb-1 opacity-60">Titre anglais</label>
+                  <input type="text" className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                     value={filmData.translated_title} onChange={(e) => setFilmData({ ...filmData, translated_title: e.target.value })} />
                 </div>
               </div>
 
               <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
                 <div>
-                  <label className="text-white/60 text-sm block mb-1">Durée (sec)</label>
-                  <input type="number" className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                  <label className="text-sm block mb-1 opacity-60">Durée (sec)</label>
+                  <input type="number" className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                     value={filmData.duration} onChange={(e) => setFilmData({ ...filmData, duration: e.target.value })} />
                 </div>
                 <div>
-                  <label className="text-white/60 text-sm block mb-1">Type</label>
-                  <select className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                  <label className="text-sm block mb-1 opacity-60">Type</label>
+                  <select className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                     value={filmData.type} onChange={(e) => setFilmData({ ...filmData, type: e.target.value })}>
                     <option value="hybride">Hybride</option>
                     <option value="total_ia">100% IA</option>
                   </select>
                 </div>
                 <div>
-                  <label className="text-white/60 text-sm block mb-1">Langue</label>
-                  <input type="text" className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                  <label className="text-sm block mb-1 opacity-60">Langue</label>
+                  <input type="text" className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                     value={filmData.language} onChange={(e) => setFilmData({ ...filmData, language: e.target.value })} />
                 </div>
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Synopsis</label>
-                <textarea rows={3} className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">Synopsis</label>
+                <textarea rows={3} className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.synopsis} onChange={(e) => setFilmData({ ...filmData, synopsis: e.target.value })} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Synopsis (anglais)</label>
-                <textarea rows={3} className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">Synopsis (anglais)</label>
+                <textarea rows={3} className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.synopsis_en} onChange={(e) => setFilmData({ ...filmData, synopsis_en: e.target.value })} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Processus créatif</label>
-                <textarea rows={3} className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">Processus créatif</label>
+                <textarea rows={3} className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.creative_process} onChange={(e) => setFilmData({ ...filmData, creative_process: e.target.value })} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Outils IA utilisés</label>
-                <textarea rows={2} className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">Outils IA utilisés</label>
+                <textarea rows={2} className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.ai_tools} onChange={(e) => setFilmData({ ...filmData, ai_tools: e.target.value })} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">URL YouTube</label>
-                <input type="url" className="w-full bg-gray-800 border border-white/10 rounded-lg px-4 py-2.5 text-white"
+                <label className="text-sm block mb-1 opacity-60">URL YouTube</label>
+                <input type="url" className="w-full rounded-lg px-4 py-2.5" style={{ background: 'var(--bg-card)', border: '1px solid var(--border-color)', color: 'var(--text-primary)' }}
                   value={filmData.youtube_link} onChange={(e) => setFilmData({ ...filmData, youtube_link: e.target.value })} />
               </div>
             </div>
 
-            <div className="bg-gray-900 rounded-xl p-6 border border-white/10 space-y-4">
+            <div className="rounded-xl p-6 space-y-4" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
               <h2 className="text-lg font-semibold text-white">Fichiers</h2>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Vidéo (MP4/MOV, max 300MB)</label>
-                <input type="file" accept=".mp4,.mov" className="w-full text-white/60 text-sm"
+                <label className="text-sm block mb-1 opacity-60">Vidéo (MP4/MOV, max 300MB)</label>
+                <input type="file" accept=".mp4,.mov" className="w-full text-sm opacity-60"
                   onChange={(e) => setVideoFile(e.target.files[0])} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Image principale (JPEG/PNG/WebP)</label>
-                <input type="file" accept=".jpg,.jpeg,.png,.webp" className="w-full text-white/60 text-sm"
+                <label className="text-sm block mb-1 opacity-60">Image principale (JPEG/PNG/WebP)</label>
+                <input type="file" accept=".jpg,.jpeg,.png,.webp" className="w-full text-sm opacity-60"
                   onChange={(e) => setImageFile(e.target.files[0])} />
               </div>
 
               <div>
-                <label className="text-white/60 text-sm block mb-1">Sous-titres (SRT)</label>
-                <input type="file" accept=".srt" className="w-full text-white/60 text-sm"
+                <label className="text-sm block mb-1 opacity-60">Sous-titres (SRT)</label>
+                <input type="file" accept=".srt" className="w-full text-sm opacity-60"
                   onChange={(e) => setSrtFile(e.target.files[0])} />
               </div>
             </div>
 
-            <div className="bg-gray-900 rounded-xl p-6 border border-white/10">
+            <div className="rounded-xl p-6" style={{ background: 'var(--bg-secondary)', border: '1px solid var(--border-color)' }}>
               <label className="flex items-start gap-3 cursor-pointer">
                 <input type="checkbox" className="mt-1"
                   checked={filmData.rgpd_accepted} onChange={(e) => setFilmData({ ...filmData, rgpd_accepted: e.target.checked })} />
-                <span className="text-white/60 text-sm">
+                <span className="text-sm opacity-60">
                   J'accepte que mes données personnelles soient traitées dans le cadre du festival Mars.A.I conformément au RGPD. *
                 </span>
               </label>


### PR DESCRIPTION
## Summary
- Add ThemeContext with localStorage persistence and data-theme attribute on html
- Add Sun/Moon toggle button in Navbar (desktop + mobile)
- Define CSS custom properties for seamless dark/light theming across all public pages and components

## Test plan
- [ ] Verify Sun/Moon toggle button appears in Navbar on desktop and mobile
- [ ] Click toggle and confirm all pages switch between dark and light themes
- [ ] Refresh the page and verify the theme preference persists
- [ ] Check that accent colors (purple, pink, cyan gradients) remain consistent in both themes
- [ ] Verify all text is readable in both themes

🤖 Generated with [Claude Code](https://claude.com/claude-code)